### PR TITLE
Update Dockerfile of step-ca-bootstrap

### DIFF
--- a/docker/step-ca-bootstrap/Dockerfile
+++ b/docker/step-ca-bootstrap/Dockerfile
@@ -1,4 +1,4 @@
-FROM smallstep/step-cli:latest
+FROM smallstep/step-cli:0.22.1
 
 ENV CA_NAME="Step CA"
 ENV CA_DNS="127.0.0.1"
@@ -6,7 +6,7 @@ ENV CA_ADDRESS=":9000"
 ENV CA_DEFAULT_PROVISIONER="admin"
 ENV CA_URL="https://127.0.0.1:9000"
 
-ENV KUBE_LATEST_VERSION="v1.18.2"
+ENV KUBE_LATEST_VERSION="v1.25.3"
 
 USER root
 RUN apk --update add expect && \


### PR DESCRIPTION
pin step-cli version, update kubectl version

### Description
The mentioned image was build over 1 year ago, which leads to 5 crit and 30+ high priority vulnerabilities.

### Solution
Update Dockerfile to quickly increase security.
Important: A build of the Image has to be triggered!

### Longterm
As the image is based on the smallstep-cli image it should be aligned with build and versioning of the cli